### PR TITLE
fix(ecs): dispatch OnSet observers off worker threads

### DIFF
--- a/include/gaia/ecs/api.h
+++ b/include/gaia/ecs/api.h
@@ -129,6 +129,51 @@ namespace gaia {
 		void unlock(World& world);
 		bool locked(const World& world);
 
+#if GAIA_OBSERVERS_ENABLED
+		// Deferred observer-notification API
+		//
+		// Observer dispatch mutates world-owned state and runs user callbacks, so it cannot happen
+		// on a worker thread. Regions whose writes may run in parallel record notifications instead
+		// and let the coordinator deliver them after the region joins.
+
+		//! Slot value used while no deferred-notification region is active on this thread.
+		inline static constexpr uint32_t BadDeferOnSetSlot = (uint32_t)-1;
+
+		void world_defer_on_set_begin(World& world, uint32_t slotCount);
+		void world_defer_on_set_end(World& world);
+
+		//! Work-item slot the calling thread currently records deferred notifications into.
+		//! Thread-local so a work item keeps its own queue regardless of which thread runs it,
+		//! including schedulers that execute work inline on the caller thread.
+		GAIA_NODISCARD inline uint32_t& defer_on_set_slot_ref() {
+			static thread_local uint32_t s_slot = BadDeferOnSetSlot;
+			return s_slot;
+		}
+
+		//! Returns the deferred-notification slot owned by the calling thread.
+		GAIA_NODISCARD inline uint32_t defer_on_set_slot() {
+			return defer_on_set_slot_ref();
+		}
+
+		//! Binds the calling thread to a deferred-notification slot for the lifetime of the scope.
+		class DeferOnSetSlotScope final {
+			uint32_t m_prev;
+
+		public:
+			explicit DeferOnSetSlotScope(uint32_t slot): m_prev(defer_on_set_slot_ref()) {
+				defer_on_set_slot_ref() = slot;
+			}
+			~DeferOnSetSlotScope() {
+				defer_on_set_slot_ref() = m_prev;
+			}
+
+			DeferOnSetSlotScope(DeferOnSetSlotScope&&) = delete;
+			DeferOnSetSlotScope(const DeferOnSetSlotScope&) = delete;
+			DeferOnSetSlotScope& operator=(DeferOnSetSlotScope&&) = delete;
+			DeferOnSetSlotScope& operator=(const DeferOnSetSlotScope&) = delete;
+		};
+#endif
+
 		// CommandBuffer API
 
 		CommandBufferST& cmd_buffer_st_get(World& world);

--- a/include/gaia/ecs/query.h
+++ b/include/gaia/ecs/query.h
@@ -2006,6 +2006,62 @@ namespace gaia {
 					return true;
 				}
 
+				//! Records `OnSet` notifications produced by a parallel region instead of dispatching
+				//! them from worker threads, and delivers them on the coordinator thread once the
+				//! region joins. Observers therefore always run on the thread that started the query,
+				//! in work-item order, exactly like the serial path.
+				class ParallelOnSetScope final {
+#if GAIA_OBSERVERS_ENABLED
+					World* m_pWorld;
+#endif
+
+				public:
+					ParallelOnSetScope([[maybe_unused]] World& world, [[maybe_unused]] uint32_t itemCount)
+#if GAIA_OBSERVERS_ENABLED
+							: m_pWorld(&world) {
+						world_defer_on_set_begin(*m_pWorld, itemCount);
+					}
+#else
+					{
+					}
+#endif
+
+					~ParallelOnSetScope() {
+#if GAIA_OBSERVERS_ENABLED
+						world_defer_on_set_end(*m_pWorld);
+#endif
+					}
+
+					ParallelOnSetScope(ParallelOnSetScope&&) = delete;
+					ParallelOnSetScope(const ParallelOnSetScope&) = delete;
+					ParallelOnSetScope& operator=(ParallelOnSetScope&&) = delete;
+					ParallelOnSetScope& operator=(const ParallelOnSetScope&) = delete;
+				};
+
+				//! Binds a parallel work-item range to its deferred-notification slot for the lifetime
+				//! of the scope. Work items are distributed in disjoint ranges, so the first item of a
+				//! range identifies a queue no other thread writes to.
+				class ParallelOnSetSlot final {
+#if GAIA_OBSERVERS_ENABLED
+					DeferOnSetSlotScope m_scope;
+#endif
+
+				public:
+					explicit ParallelOnSetSlot([[maybe_unused]] uint32_t idxStart)
+#if GAIA_OBSERVERS_ENABLED
+							: m_scope(idxStart) {
+					}
+#else
+					{
+					}
+#endif
+
+					ParallelOnSetSlot(ParallelOnSetSlot&&) = delete;
+					ParallelOnSetSlot(const ParallelOnSetSlot&) = delete;
+					ParallelOnSetSlot& operator=(ParallelOnSetSlot&&) = delete;
+					ParallelOnSetSlot& operator=(const ParallelOnSetSlot&) = delete;
+				};
+
 				//! \cond INTERNAL
 				template <typename TIter>
 				static void finish_iter_writes(TIter& it) {
@@ -2362,6 +2418,11 @@ namespace gaia {
 					auto* pWorld = pJobCtx->pWorld;
 					if (pWorld != nullptr) {
 						unlock(*pWorld);
+#if GAIA_OBSERVERS_ENABLED
+						// Deliver the notifications workers recorded. This runs once the job finished, on
+						// the thread that waited for it, with the world already unlocked.
+						world_defer_on_set_end(*pWorld);
+#endif
 						commit_cmd_buffer_st(*pWorld);
 						commit_cmd_buffer_mt(*pWorld);
 						if (pJobCtx->pSelf != nullptr)
@@ -2394,8 +2455,15 @@ namespace gaia {
 					desc.execType = ExecType;
 					desc.invoke = [](void* pInvokeCtx, uint32_t idxStart, uint32_t idxEnd) {
 						auto& ctx = *reinterpret_cast<QueryJobCtx<Func, TMode>*>(pInvokeCtx);
+						ParallelOnSetSlot slot(idxStart);
 						run_query_func<Func, TMode>(ctx.pWorld, ctx.func, std::span(&ctx.batches[idxStart], idxEnd - idxStart));
 					};
+
+#if GAIA_OBSERVERS_ENABLED
+					// Matched by world_defer_on_set_end() in cleanup_query_job(), which runs after the
+					// job completed and the world was unlocked.
+					world_defer_on_set_begin(*pWorld, desc.itemCount);
+#endif
 
 					return sched_add_par(world_sched(*pWorld), desc, pCtx, &cleanup_query_job<Func, TMode>);
 				}
@@ -2721,18 +2789,27 @@ namespace gaia {
 					desc.execType = ExecType;
 					desc.invoke = [](void* pCtx, uint32_t idxStart, uint32_t idxEnd) {
 						auto& ctx = *reinterpret_cast<ParallelQueryBatchCtx*>(pCtx);
+						ParallelOnSetSlot slot(idxStart);
 						run_query_func<Func, TMode>(
 								ctx.pSelf->m_storage.world(), *ctx.pFunc,
 								std::span(&ctx.pSelf->m_batches[idxStart], idxEnd - idxStart));
 					};
 
-					const auto& sched = world_sched(*m_storage.world());
-					const auto token = sched_par(sched, desc);
-					sched_wait(sched, token);
-					sched_del(sched, token);
-					m_batches.clear();
+					{
+						// Observers recorded by workers are dispatched when this scope ends, after the
+						// world is unlocked again, so callbacks see the same world state as on the
+						// serial path.
+						ParallelOnSetScope onSetScope(*m_storage.world(), desc.itemCount);
 
-					unlock(*m_storage.world());
+						const auto& sched = world_sched(*m_storage.world());
+						const auto token = sched_par(sched, desc);
+						sched_wait(sched, token);
+						sched_del(sched, token);
+						m_batches.clear();
+
+						unlock(*m_storage.world());
+					}
+
 					// Commit the command buffer.
 					// TODO: Smart handling necessary
 					commit_cmd_buffer_st(*m_storage.world());
@@ -2897,18 +2974,24 @@ namespace gaia {
 					desc.execType = ExecType;
 					desc.invoke = [](void* pCtx, uint32_t idxStart, uint32_t idxEnd) {
 						auto& ctx = *reinterpret_cast<ParallelQueryBatchCtx*>(pCtx);
+						ParallelOnSetSlot slot(idxStart);
 						run_query_func<Func, TMode>(
 								ctx.pSelf->m_storage.world(), *ctx.pFunc,
 								std::span(&ctx.pSelf->m_batches[idxStart], idxEnd - idxStart));
 					};
 
-					const auto& sched = world_sched(*m_storage.world());
-					const auto token = sched_par(sched, desc);
-					sched_wait(sched, token);
-					sched_del(sched, token);
-					m_batches.clear();
+					{
+						ParallelOnSetScope onSetScope(*m_storage.world(), desc.itemCount);
 
-					unlock(*m_storage.world());
+						const auto& sched = world_sched(*m_storage.world());
+						const auto token = sched_par(sched, desc);
+						sched_wait(sched, token);
+						sched_del(sched, token);
+						m_batches.clear();
+
+						unlock(*m_storage.world());
+					}
+
 					// Commit the command buffer.
 					// TODO: Smart handling necessary
 					commit_cmd_buffer_st(*m_storage.world());
@@ -3270,18 +3353,24 @@ namespace gaia {
 					desc.execType = ExecType;
 					desc.invoke = [](void* pCtx, uint32_t idxStart, uint32_t idxEnd) {
 						auto& ctx = *reinterpret_cast<ParallelQueryBatchCtx*>(pCtx);
+						ParallelOnSetSlot slot(idxStart);
 						run_query_func_runtime(
 								ctx.pSelf->m_storage.world(), *ctx.pFunc, std::span(&ctx.pSelf->m_batches[idxStart], idxEnd - idxStart),
 								ctx.constraints);
 					};
 
-					const auto& sched = world_sched(*m_storage.world());
-					const auto token = sched_par(sched, desc);
-					sched_wait(sched, token);
-					sched_del(sched, token);
-					m_batches.clear();
+					{
+						ParallelOnSetScope onSetScope(*m_storage.world(), desc.itemCount);
 
-					unlock(*m_storage.world());
+						const auto& sched = world_sched(*m_storage.world());
+						const auto token = sched_par(sched, desc);
+						sched_wait(sched, token);
+						sched_del(sched, token);
+						m_batches.clear();
+
+						unlock(*m_storage.world());
+					}
+
 					commit_cmd_buffer_st(*m_storage.world());
 					commit_cmd_buffer_mt(*m_storage.world());
 				}
@@ -3411,18 +3500,24 @@ namespace gaia {
 					desc.execType = ExecType;
 					desc.invoke = [](void* pCtx, uint32_t idxStart, uint32_t idxEnd) {
 						auto& ctx = *reinterpret_cast<ParallelQueryBatchCtx*>(pCtx);
+						ParallelOnSetSlot slot(idxStart);
 						run_query_func_runtime(
 								ctx.pSelf->m_storage.world(), *ctx.pFunc, std::span(&ctx.pSelf->m_batches[idxStart], idxEnd - idxStart),
 								ctx.constraints);
 					};
 
-					const auto& sched = world_sched(*m_storage.world());
-					const auto token = sched_par(sched, desc);
-					sched_wait(sched, token);
-					sched_del(sched, token);
-					m_batches.clear();
+					{
+						ParallelOnSetScope onSetScope(*m_storage.world(), desc.itemCount);
 
-					unlock(*m_storage.world());
+						const auto& sched = world_sched(*m_storage.world());
+						const auto token = sched_par(sched, desc);
+						sched_wait(sched, token);
+						sched_del(sched, token);
+						m_batches.clear();
+
+						unlock(*m_storage.world());
+					}
+
 					commit_cmd_buffer_st(*m_storage.world());
 					commit_cmd_buffer_mt(*m_storage.world());
 				}

--- a/include/gaia/ecs/world.h
+++ b/include/gaia/ecs/world.h
@@ -633,6 +633,20 @@ namespace gaia {
 #if GAIA_OBSERVERS_ENABLED
 			//! Observers
 			ObserverRegistry m_observers;
+
+			//! One deferred `OnSet` notification recorded by a worker thread.
+			struct DeferredOnSet {
+				//! Component or pair id that was written.
+				Entity term;
+				//! Entity the write applied to.
+				Entity entity;
+			};
+
+			//! Notifications recorded while writes run outside the coordinator thread. One queue per
+			//! recording slot so workers never share a container. Drained once the region joins.
+			cnt::darray<cnt::darray<DeferredOnSet>> m_deferredOnSet;
+			//! Greater than zero while writes must record notifications instead of dispatching them.
+			uint32_t m_deferOnSetDepth = 0;
 #endif
 
 #if GAIA_SYSTEMS_ENABLED
@@ -7914,6 +7928,55 @@ namespace gaia {
 				return m_observers;
 			}
 
+			//! Starts recording `OnSet` notifications instead of dispatching them right away.
+			//! Called by the coordinator before a region whose writes may run on worker threads.
+			//! \param slotCount Number of work items that can record concurrently.
+			void defer_on_set_begin(uint32_t slotCount) {
+				GAIA_ASSERT(m_deferOnSetDepth != (uint32_t)-1);
+				if (m_deferOnSetDepth++ != 0)
+					return;
+
+				// One queue per work item. Items are distributed to threads in disjoint ranges, so a
+				// queue is only ever touched by the single thread processing that item and no
+				// synchronization is needed while the region is open.
+				m_deferredOnSet.resize(slotCount);
+				for (auto& queue: m_deferredOnSet)
+					queue.clear();
+			}
+
+			//! Stops recording `OnSet` notifications and dispatches everything recorded since the
+			//! matching defer_on_set_begin(). Notifications run on the calling thread in work-item
+			//! order, so observers see the same sequence no matter how work was distributed.
+			void defer_on_set_end() {
+				GAIA_ASSERT(m_deferOnSetDepth > 0);
+				if (--m_deferOnSetDepth != 0)
+					return;
+
+				// Observer callbacks may trigger writes of their own. Those are dispatched directly
+				// because the recording region already ended, so move the queues aside before
+				// walking them.
+				auto pending = GAIA_MOV(m_deferredOnSet);
+				m_deferredOnSet = {};
+				for (const auto& queue: pending) {
+					for (const auto& item: queue)
+						world_notify_on_set_entity(*this, item.term, item.entity);
+				}
+			}
+
+			//! Returns whether `OnSet` notifications are currently being recorded.
+			GAIA_NODISCARD bool defer_on_set_active() const {
+				return m_deferOnSetDepth != 0;
+			}
+
+			//! Records an `OnSet` notification for later dispatch.
+			//! \param slot Work-item slot owned exclusively by the calling thread.
+			//! \param term Component or pair id that was written.
+			//! \param entity Entity the write applied to.
+			void defer_on_set_record(uint32_t slot, Entity term, Entity entity) {
+				GAIA_ASSERT(slot < m_deferredOnSet.size());
+				m_deferredOnSet[slot].push_back({term, entity});
+			}
+
 #endif
 
 			//----------------------------------------------------------------------
@@ -13711,6 +13774,22 @@ namespace gaia {
 			world.invalidate_sorted_queries();
 		}
 
+#if GAIA_OBSERVERS_ENABLED
+		//! Starts recording `OnSet` notifications in \a world instead of dispatching them.
+		//! \param world World owning the observers.
+		//! \param slotCount Number of work items that can record concurrently.
+		inline void world_defer_on_set_begin(World& world, uint32_t slotCount) {
+			world.defer_on_set_begin(slotCount);
+		}
+
+		//! Dispatches the `OnSet` notifications recorded in \a world since the matching
+		//! world_defer_on_set_begin().
+		//! \param world World owning the observers.
+		inline void world_defer_on_set_end(World& world) {
+			world.defer_on_set_end();
+		}
+#endif
+
 		//! Checks whether \a entity satisfies \a term using normal semantic matching.
 		//! \param world World to query.
 		//! \param entity Entity to test.
@@ -14355,6 +14434,17 @@ namespace gaia {
 			if (from >= to)
 				return;
 
+			// Observer dispatch mutates world-owned state and runs user code. Neither is safe from a
+			// worker thread, so inside a deferring region the notification is only recorded here and
+			// the coordinator dispatches it after the region joins.
+			if (world.defer_on_set_active()) {
+				const auto slot = defer_on_set_slot();
+				GAIA_ASSERT(slot != BadDeferOnSetSlot);
+				for (uint32_t row = from; row < to; ++row)
+					world.defer_on_set_record(slot, term, entities[row]);
+				return;
+			}
+
 			world.observers().on_set(world, term, EntitySpan{entities.data() + from, uint32_t(to - from)});
 #else
 			(void)world;
@@ -14486,6 +14576,15 @@ namespace gaia {
 				return;
 			if (!world.observers().has_on_set_observers(term))
 				return;
+
+			// See world_notify_on_set(): inside a deferring region the notification is recorded and
+			// dispatched by the coordinator once the region joins.
+			if (world.defer_on_set_active()) {
+				const auto slot = defer_on_set_slot();
+				GAIA_ASSERT(slot != BadDeferOnSetSlot);
+				world.defer_on_set_record(slot, term, entity);
+				return;
+			}
 
 			world.observers().on_set(world, term, EntitySpan{&entity, 1});
 #else

--- a/src/test/src/test_mt.cpp
+++ b/src/test/src/test_mt.cpp
@@ -624,6 +624,75 @@ TEST_CASE("ECS - Query uses external scheduler") {
 	CHECK(sum == (EntityCount - 1) * EntityCount / 2);
 }
 
+#if GAIA_OBSERVERS_ENABLED
+TEST_CASE("ECS - Parallel query writes notify OnSet observers on the caller thread") {
+	auto& tp = mt::ThreadPool::get();
+	const auto threads = tp.hw_thread_cnt();
+	tp.set_max_workers(threads, threads);
+
+	TestWorld twld;
+
+	// Enough entities to span many chunks. A small count fits into a single batch,
+	// the work never fans out, and the test would pass vacuously.
+	constexpr uint32_t EntityCount = 20000;
+
+	const auto mainThread = std::this_thread::get_id();
+	std::atomic_uint32_t observerCalls = 0;
+	std::atomic_uint32_t observerForeignThreadCalls = 0;
+
+	(void)wld.observer()
+			.event(ecs::ObserverEvent::OnSet)
+			.all<Position>()
+			.on_each([&](ecs::Entity, const Position&) {
+				observerCalls.fetch_add(1, std::memory_order_relaxed);
+				if (std::this_thread::get_id() != mainThread)
+					observerForeignThreadCalls.fetch_add(1, std::memory_order_relaxed);
+			})
+			.entity();
+
+	GAIA_FOR(EntityCount) {
+		auto e = wld.add();
+		wld.add<Position>(e, {float(i), 0.0F, 0.0F});
+		wld.add<Acceleration>(e, {1.0F, 2.0F, 3.0F});
+	}
+
+	observerCalls.store(0, std::memory_order_relaxed);
+	observerForeignThreadCalls.store(0, std::memory_order_relaxed);
+
+	auto q = wld.query().all<Position&>().all<const Acceleration>();
+	auto job = q.job(
+			[](ecs::Iter& it) {
+				auto pos = it.view_mut<Position>(0);
+				auto acc = it.view<Acceleration>(1);
+				GAIA_FOR_(it.size(), i) {
+					pos[i].x += acc[i].x;
+					pos[i].y += acc[i].y;
+				}
+			},
+			ecs::QueryExecType::Parallel);
+	job.submit();
+	job.wait();
+	job.del();
+
+	// Observers must fire exactly once per written entity and never from a worker thread.
+	CHECK(observerCalls.load(std::memory_order_relaxed) == EntityCount);
+	CHECK(observerForeignThreadCalls.load(std::memory_order_relaxed) == 0);
+
+	// The payload has to match what a serial run would have produced.
+	uint32_t rows = 0;
+	double sum = 0.0;
+	wld.query().all<const Position>().each([&](ecs::Iter& it) {
+		auto pos = it.view<Position>(0);
+		GAIA_FOR_(it.size(), i) {
+			++rows;
+			sum += (double)pos[i].x + (double)pos[i].y;
+		}
+	});
+	CHECK(rows == EntityCount);
+	CHECK(sum == doctest::Approx((double)EntityCount * (EntityCount - 1) / 2.0 + (double)EntityCount * 3.0));
+}
+#endif
+
 TEST_CASE("ECS - Systems use external scheduler") {
 	TestWorld twld;
 	ExternalSchedProbe probe;


### PR DESCRIPTION

## Symptom

A parallel query that writes a component carrying a live `OnSet` observer corrupts the
heap. On my machine it fails 8/8 runs with `SIGSEGV`, `double free or corruption (out)`,
`call_ctor: Assertion (pData != nullptr) failed`, or
`World::observer_callback_leave: Assertion (m_observerCallbackDepth != 0) failed`
(`world.h:838`). ThreadSanitizer reports 29 data races on the same workload.

The same write is clean serially, and clean in parallel with no observer on the written
component. It needs enough entities for the query to actually fan out — ~20k here; at 2k
the scheduler tends to run everything inline and it passes.

## Minimal repro

```cpp
ecs::World w;
w.observer().event(ecs::ObserverEvent::OnSet).all<Pos>()
 .on_each([](ecs::Entity, const Pos&) {}).entity();

for (uint32_t i = 0; i < 20000; ++i) {
    auto e = w.add();
    w.add<Pos>(e, {float(i), 0, 0});
    w.add<Vel>(e, {1, 2, 3});
}

auto q = w.query().all<Pos&>().all<const Vel>();
auto job = q.job([](ecs::Iter& it) {
    auto pos = it.view_mut<Pos>(0);
    auto vel = it.view<Vel>(1);
    for (uint32_t i = 0; i < it.size(); ++i) pos[i].x += vel[i].x;
}, ecs::QueryExecType::Parallel);
job.submit(); job.wait(); job.del();
```

## Root cause

Workers reach observer dispatch from inside the parallel region:

```
run_query_func           query.h:2179
  -> finish_iter_writes  query.h:2011
  -> Chunk::finish_write chunk.h:356
  -> world_notify_on_set world.h:14406
  -> ObserverRegistry::on_set  observer_registry.inl:544
```

`DirectDispatcher::on_set` clears and refills the registry-owned scratch
`m_relevant_observers_tmp` (`observer_registry.h:186`) and bumps the shared
`m_current_match_stamp` (`observer_registry.h:208`) on every call, so concurrent workers
clobber each other. It also runs user callbacks on worker threads and re-enters
`obs.query.fetch()`, racing the query cache and `QueryImplStorage::m_pInfo`
(`query.h:463-465`). The `#if GAIA_ASSERT_ENABLED` observer depth counter
(`world.h:831-840`) is a plain `uint32_t` and trips for the same reason.

## Fix

The parallel path already defers its other bookkeeping — iterators run with
`write_im = false` so version bumps publish after the callback, and structural commands
are queued and committed only after `unlock()`. Observer publication was the one piece
left inside the worker.

This records `OnSet` notifications into a per-work-item queue while a parallel region is
open, and dispatches them from the coordinator after the join, with the world unlocked.
Observers now run on the thread that started the query, in work-item order — the same
guarantees the serial path already gives. No serial-path behaviour changes.

Queues are keyed by the `idxStart` of each scheduler range rather than a worker index, so
the fix holds for schedulers installed via `World::set_sched()`, including ones that
execute work inline on the calling thread (as the existing `ExternalSchedProbe` tests do).

Applied to all five parallel dispatch sites, including the async `q.job(...)` path, whose
region closes in `cleanup_query_job()`. All of it is behind `GAIA_OBSERVERS_ENABLED`.

## Semantics note

The cheaper alternative — making the registry scratch thread-local — silences the race but
leaves user callbacks running on worker threads in nondeterministic order, which would
newly define parallel observer semantics as unordered rather than fixing the existing
ones. I went with hoisting publication to the coordinator so the parallel path matches the
serial path instead. Happy to switch if you'd rather define it the other way.

## Tests

New case in `src/test/src/test_mt.cpp` on the real `ThreadPool` path: 20 000 entities, an
`OnSet` observer, a `QueryExecType::Parallel` write. It asserts the observer fires exactly
once per entity, **never from a non-caller thread**, and that the payload matches a serial
run. It crashes reliably without the fix.

## Before / after

| | test cases | assertions | failed |
|---|---|---|---|
| `main` @ 93718a69 | 635 | 2 234 237 | 0 |
| with this change | 636 | 2 234 241 | 0 |

TSAN on the repro: **29 races → 0**. The new test: 8/8 `SIGSEGV` → 8/8 pass.

## Known adjacent issue (not addressed here)

`Chunk::update_world_version` (`chunk.h:1858`) also calls
`world_invalidate_sorted_queries_for_entity` from workers, reaching
`QueryInfo::invalidate_sort` (`query_info.h:1012`) — an unsynchronised flag write plus a
`QueryCache` lookup. It hangs off the version bump rather than the notify path, so it is a
differently-shaped change and I left it out to keep this PR one thing. It is benign in
practice today (idempotent OR; the map is empty unless a sorted query is registered) but
would matter against a concurrent sorted-query registration. Happy to follow up.

## Note on `single_include/gaia.h`

Regenerated with `./make_single_header.sh`. `clang-format` was not available on my machine
so the script skipped the formatting pass — please re-run it if the formatting matters for
the merge.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
